### PR TITLE
add npm install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Shows you how to make a single distributable
 
 ```
+npm install
 bare-dev vendor sync
 bare-dev configure
 bare-dev build


### PR DESCRIPTION
A very small readme update to add `npm install` in case others make the silly mistake I did.

After running `bare-dev vendor sync` successfully I tried `bare-dev configure` and got this cmake error:

```
❯ bare-dev configure
-- Configuring done (36.5s)
CMake Error at CMakeLists.txt:13 (add_library):
  No SOURCES given to target: bare_distributable_hello_world


CMake Generate step failed.  Build files cannot be regenerated correctly.
error: spawn() failed
```

I'm new to cmake so thought something weird was going on. Nope, just had to `npm install` 🤦‍♂️

I don't know how we might catch that error to show something more bare-specific but that could be cool.